### PR TITLE
Added "type" parameter to Predicate constructor function in java-sdk.

### DIFF
--- a/sdk/java-sdk/src/main/java/com/evernym/verity/sdk/protocols/presentproof/common/Predicate.java
+++ b/sdk/java-sdk/src/main/java/com/evernym/verity/sdk/protocols/presentproof/common/Predicate.java
@@ -11,16 +11,17 @@ import static com.evernym.verity.sdk.utils.JsonUtil.makeArray;
 public class Predicate implements AsJsonObject  {
 
     /**
-     * Constructs the Predicate object with the given attribute name, value and given restrictions
+     * Constructs the Predicate object with the given attribute name, type, value and given restrictions
 
      * @param name the attribute name
-     * @param value the value the given attribute must be greater than
+     * @param type the type only is supported "<=", "<", ">=" or ">"
+     * @param value the value the given attribute must satisfy the type
      * @param restrictions the restrictions for requested presentation for this predicate
      */
-    public Predicate(String name, int value, Restriction... restrictions) {
+    public Predicate(String name, String type, int value, Restriction... restrictions) {
         this.data = new JSONObject()
                 .put("name", name)
-                .put("p_type", ">=")
+                .put("p_type", type)
                 .put("p_value", value)
                 .put("restrictions", makeArray(restrictions));
     }

--- a/sdk/java-sdk/src/test/java/com/evernym/verity/sdk/protocols/presentproof/v1_0/PresentProofTest.java
+++ b/sdk/java-sdk/src/test/java/com/evernym/verity/sdk/protocols/presentproof/v1_0/PresentProofTest.java
@@ -29,7 +29,7 @@ public class PresentProofTest {
             .issuerDid("UOISDFOPUASOFIUSAF")
             .build();
     private final Attribute attr1 = PresentProofV1_0.attribute("age", r1);
-    private final Predicate pred1 = new Predicate("age", 18, r1);
+    private final Predicate pred1 = new Predicate("age", ">=", 18, r1);
 
     @Test
     public void testGetMessageType() {


### PR DESCRIPTION
Currently, when creating a Predicate in Java-sdk, only ">=" is supported, so that "<=", "<", ">=" and ">" are all available as parameters.

The parameter name was set as "type" referring to "p_type".